### PR TITLE
John revisions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Don't check this into git
+/.history/*

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# anontrans
+
+## Libraries:
+- [Soundcite](https://soundcite.knightlab.com/): used to display inline sound clips for the podcast interviews.
+  - Usage: `<div class="soundcite" data-url="URL_OF_AUDIO_STREAM_FILE" ... />`
+
+## Interviews/Transcripts
+- [Episode_156_Sophie_B](https://mentalpod.com/Sophie-Bull-podcast) clip starts at ~15:00
+- [Episode_099_Jess](https://mentalpod.com/Jess-Podcast) clip starts at
+- [342_When_Your_Trauma_Informs_Your_Turn_Ons](https://mentalpod.com/archives/4568) clip starts at

--- a/index.html
+++ b/index.html
@@ -147,7 +147,7 @@
                                 Bipolar II, hypomania as well as the abusive “relationship” she had with a 22 year-old
                                 when she was 12
                                 and how she began self-harming then. </h3>
-                        <div class="soundcite" data-url="https://content.production.cdn.art19.com/validation=1652896164,47c88249-6dfa-5c2f-97a2-d19f0baacd3f,KuGw-e9560UlnCNApHPt30BRcc0/episodes/d1a310e0-4cf5-4186-bc5d-671a65db2e7b/1399f7d3a3af4bf52c386e3b437d4561222994b9549bcd42ee3b9e9b1b6cd1604c9eb188c3af9664c4dd28a789889db9fae6ecb4d24ed5c9e8adc664c70e68f0/Episode_156_Sophie_B.mp3%3Ft%3D1576124164%26tdtok%3DeyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6Ink5dEdIIn0.eyJpc3MiOiJvbW55IiwiaWF0IjoxNjMxNzU1MTAxLCJ0ZC1yZWciOmZhbHNlLCJ0ZC1hZHMiOiJub25lIn0.mp3" data-start="836000" data-end="1360000" data-plays="1">Excerpt of Audio</div>
+                        <div class="soundcite" data-url="https://content.production.cdn.art19.com/validation=1663445785,3b403ebf-d010-5404-9a11-2f74f623a092,vEBsUcFRNexuljWhxbSsOO6dD7w/episodes/d1a310e0-4cf5-4186-bc5d-671a65db2e7b/6023b5774b69d7c1342b8764f7011a0d7940b79aa895c938b2426b56b1c9906a43dadcb6c17639ca24914ff1327b440ced74b8c9c53c7b0ef9114801fcbd6de1/Episode_156_Sophie_B.mp3%3Ft%3D1576124164%26tdtok%3DeyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6Ink5dEdIIn0.eyJpc3MiOiJvbW55IiwiaWF0IjoxNjMxNzU1MTAxLCJ0ZC1yZWciOmZhbHNlLCJ0ZC1hZHMiOiJub25lIn0.mp3" data-start="836000" data-end="1360000" data-plays="1">Excerpt of Audio</div>
 
                         <p class="paul">
                                 <element class="speaker">Paul:</element>One of the things that I like to talk about, if
@@ -461,7 +461,7 @@ In the film’s well-handled subplot, Frederique Meininger is superb as the girl
                                 the struggling to find words to categorize the sex she wanted and got at 12, from a 27
                                 year-old man. She also talk about the self-doubt of giving up her fledgling comedy
                                 career to become a therapist. </h3>
-                         <div class="soundcite" data-url="https://content.production.cdn.art19.com/validation=1652896926,a72fa1f5-87c4-57ed-94e5-2550b035e2ab,0kGPtvXnHLs0I9X2a67lHkjw2IQ/episodes/537766cb-d1f1-496e-b5cf-2542c3369181/1cedc7417a7edee948ce06aeb5dee2cea85c52f2f7965da09d26b1d8c1fb17ace531205acfc74b59d178b6b1db7e137b1ad162cd051654260558d961742b016f/Episode_099_Jess.mp3%3Ft%3D1576124241%26tdtok%3DeyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6Ink5dEdIIn0.eyJpc3MiOiJvbW55IiwiaWF0IjoxNjMxNzU5NTE4LCJ0ZC1yZWciOmZhbHNlLCJ0ZC1hZHMiOiJub25lIn0.mp3" data-start="3441000" data-end="4520000" data-plays="1">Excerpt of Audio</div>
+                         <div class="soundcite" data-url="https://content.production.cdn.art19.com/validation=1663449094,d001e8eb-44a6-521e-8264-36cdcdf96a08,uZ1f9BDhdTSN5UpUhpbz9-yFb7g/episodes/537766cb-d1f1-496e-b5cf-2542c3369181/b1a320f786ee6ab0677c3d8fd9c8dfde1ab5ccfe3caf24330d9fbffdcf8bd2e25fe31f7fd306e064a5fc55dfff809f20f3d3b901f1351312259286cc4f1dbcbb/Episode_099_Jess.mp3%3Ft%3D1576124241%26tdtok%3DeyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6Ink5dEdIIn0.eyJpc3MiOiJvbW55IiwiaWF0IjoxNjMxNzU5NTE4LCJ0ZC1yZWciOmZhbHNlLCJ0ZC1hZHMiOiJub25lIn0.mp3" data-start="3441000" data-end="4520000" data-plays="1">Excerpt of Audio</div>
 
 
                         <p class="paul">
@@ -881,7 +881,7 @@ In the film’s well-handled subplot, Frederique Meininger is superb as the girl
                                 shares about his years of self-destruction and bottoming out before eventually getting
                                 sober and starting the process of healing and advocating for other survivors. </h3>
 
-                                <div class="soundcite" data-url="https://content.production.cdn.art19.com/validation=1652897236,26b0cf60-7ebb-5b17-80b5-83c2f9fff92c,P2mucaQC5tSevmOA6d3Oa_eLn50/episodes/bad019ee-9b56-4952-914c-7ffce5e74f4e/e69a9326a1f7252eda2c12a3e51fa88d4b8d697b9a50905932b32deaf53245b24a870e9860bef7b96866867b6f42858030f945803c22041f9743cdf46ad4ca18/342_When_Your_Trauma_Informs_Your_Turn_Ons.mp3%3Ft%3D1576123443%26tdtok%3DeyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6Ink5dEdIIn0.eyJpc3MiOiJvbW55IiwiaWF0IjoxNjMxNzQ4MzEyLCJ0ZC1yZWciOmZhbHNlLCJ0ZC1hZHMiOiJub25lIn0.mp3" data-start="1865000" data-end="5898000" data-plays="1">Excerpt of Audio</div>
+                                <div class="soundcite" data-url="https://content.production.cdn.art19.com/validation=1663449286,636972be-e441-5cca-9bb7-3a68388c064e,n-GMVSp-VRpWYv0qxXEdSpDDs9Q/episodes/bad019ee-9b56-4952-914c-7ffce5e74f4e/69cf7a2f9c510890edc3303e74f4933fd2e19e63eab0a51392df62cf8932d57323d93cfcd9a2c96369a2feb7b70455dbf8ade98e1ab154e04c3337017cd1a4ea/342_When_Your_Trauma_Informs_Your_Turn_Ons.mp3%3Ft%3D1576123443%26tdtok%3DeyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6Ink5dEdIIn0.eyJpc3MiOiJvbW55IiwiaWF0IjoxNjMxNzQ4MzEyLCJ0ZC1yZWciOmZhbHNlLCJ0ZC1hZHMiOiJub25lIn0.mp3" data-start="1865000" data-end="5898000" data-plays="1">Excerpt of Audio</div>
 
 
                         <p class="guest">


### PR DESCRIPTION
Changes:
- [update broken/expired soundcite URLs](https://github.com/cordonc/anontrans/commit/8d0bd079f3c6e815f08a2d29558d0b8d29b7f04b)
  - Mentalpod.com fetches its podcast .mp3 files from this CDN (https://content.production.cdn.art19.com), which seems to use timed keys in the fetch URL. Will need to update the URLs again when they expire in the future.
  - I think if we upload these .mp3 files to youtube or soundcloud, we could get a permanent URL which wouldn't require manual updates in the future.
- [add readme with details about the soundcite library](https://github.com/cordonc/anontrans/commit/b38aa195b013b5f94e9942e83c05375fc8b38308)
- [add git ignore file to ignore local history change files](https://github.com/cordonc/anontrans/commit/f81cde82f075e3041ea52bafa26c0601e92a6885)


